### PR TITLE
Add support for tags_list API call

### DIFF
--- a/lib/active-campaign-rails/client.rb
+++ b/lib/active-campaign-rails/client.rb
@@ -141,6 +141,9 @@ class ActiveCampaign
         track_site_whitelist_delete: { method: 'post' },
         track_event_add: { method: 'post' },
 
+        # Tag
+        tags_list: { method: 'get'},
+
         # User
         user_add: { method: 'post' },
         user_delete: { method: 'post' },


### PR DESCRIPTION
This adds support for the tags_list API call. A GET request that returns a list of all available tags. The tags_list API call is documented here:

http://www.activecampaign.com/api/example.php?call=tags_list

